### PR TITLE
Added build arg for meteor version

### DIFF
--- a/ubuntu-bionic.dockerfile
+++ b/ubuntu-bionic.dockerfile
@@ -11,6 +11,8 @@ ENV MONGO_OPLOG_URL mongodb://mongodb/local
 ENV HOME /
 ENV LOG_TO_STDOUT 0
 
+ARG METEOR_VERSION
+
 VOLUME /var/log/meteor
 
 COPY ./etc /etc
@@ -18,7 +20,7 @@ COPY ./etc /etc
 RUN apt-get update -q -q && \
  apt-get --yes --force-yes install curl python build-essential git && \
  export METEOR_ALLOW_SUPERUSER=true && \
- curl https://install.meteor.com/ | sed s/--progress-bar/-sL/g | sh && \
+ curl https://install.meteor.com/${METEOR_VERSION:+?release=${METEOR_VERSION}} | sed s/--progress-bar/-sL/g | sh && \
  apt-get --yes --force-yes purge curl && \
  apt-get --yes --force-yes autoremove && \
  adduser --system --group meteor --home / && \

--- a/ubuntu-trusty.dockerfile
+++ b/ubuntu-trusty.dockerfile
@@ -11,6 +11,8 @@ ENV MONGO_OPLOG_URL mongodb://mongodb/local
 ENV HOME /
 ENV LOG_TO_STDOUT 0
 
+ARG METEOR_VERSION
+
 VOLUME /var/log/meteor
 
 COPY ./etc /etc
@@ -18,7 +20,7 @@ COPY ./etc /etc
 RUN apt-get update -q -q && \
  apt-get --yes --force-yes install curl python build-essential git && \
  export METEOR_ALLOW_SUPERUSER=true && \
- curl https://install.meteor.com/ | sed s/--progress-bar/-sL/g | sh && \
+ curl https://install.meteor.com/${METEOR_VERSION:+?release=${METEOR_VERSION}} | sed s/--progress-bar/-sL/g | sh && \
  apt-get --yes --force-yes purge curl && \
  apt-get --yes --force-yes autoremove && \
  adduser --system --group meteor --home / && \

--- a/ubuntu-xenial.dockerfile
+++ b/ubuntu-xenial.dockerfile
@@ -11,6 +11,8 @@ ENV MONGO_OPLOG_URL mongodb://mongodb/local
 ENV HOME /
 ENV LOG_TO_STDOUT 0
 
+ARG METEOR_VERSION
+
 VOLUME /var/log/meteor
 
 COPY ./etc /etc
@@ -18,7 +20,7 @@ COPY ./etc /etc
 RUN apt-get update -q -q && \
  apt-get --yes --force-yes install curl python build-essential git && \
  export METEOR_ALLOW_SUPERUSER=true && \
- curl https://install.meteor.com/ | sed s/--progress-bar/-sL/g | sh && \
+ curl https://install.meteor.com/${METEOR_VERSION:+?release=${METEOR_VERSION}} | sed s/--progress-bar/-sL/g | sh && \
  apt-get --yes --force-yes purge curl && \
  apt-get --yes --force-yes autoremove && \
  adduser --system --group meteor --home / && \


### PR DESCRIPTION
User would be able to specify the build arg METEOR_VERSION, to download a specific version of meteor during build time. If the arg is not supplied, the latest version of meteor would be downloaded.